### PR TITLE
Add `m.room.encrypted` support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SRC
     src/events/canonical_alias.cpp
     src/events/common.cpp
     src/events/create.cpp
+    src/events/encrypted.cpp
     src/events/encryption.cpp
     src/events/guest_access.cpp
     src/events/history_visibility.cpp
@@ -77,7 +78,7 @@ install(TARGETS ${PROJECT_NAME}
     ARCHIVE DESTINATION lib/static
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin)
-install(DIRECTORY include/ 
+install(DIRECTORY include/
     DESTINATION include/${PROJECT_NAME}
     FILES_MATCHING PATTERN "*.hpp")
 

--- a/include/mtx/events.hpp
+++ b/include/mtx/events.hpp
@@ -22,6 +22,8 @@ enum class EventType
         RoomCanonicalAlias,
         /// m.room.create
         RoomCreate,
+        /// m.room.encrypted.
+        RoomEncrypted,
         /// m.room.encryption.
         RoomEncryption,
         /// m.room.guest_access
@@ -90,6 +92,9 @@ to_json(json &obj, const Event<Content> &event)
                 break;
         case EventType::RoomCreate:
                 obj["type"] = "m.room.create";
+                break;
+        case EventType::RoomEncrypted:
+                obj["type"] = "m.room.encrypted";
                 break;
         case EventType::RoomEncryption:
                 obj["type"] = "m.room.encryption";
@@ -344,6 +349,36 @@ from_json(const json &obj, RedactionEvent<Content> &event)
                 event.room_id = obj.at("room_id");
 
         event.redacts = obj.at("redacts").get<std::string>();
+}
+
+//! Extension of the RoomEvent.
+template<class Content>
+struct EncryptedEvent : public RoomEvent<Content>
+{};
+
+template<class Content>
+void
+to_json(json &obj, const EncryptedEvent<Content> &event)
+{
+        RoomEvent<Content> base_event = event;
+        to_json(obj, base_event);
+}
+
+template<class Content>
+void
+from_json(const json &obj, EncryptedEvent<Content> &event)
+{
+        event.content          = obj.at("content").get<Content>();
+        event.event_id         = obj.at("event_id");
+        event.origin_server_ts = obj.at("origin_server_ts");
+        event.sender           = obj.at("sender");
+        event.type             = getEventType(obj.at("type").get<std::string>());
+
+        if (obj.find("unsigned") != obj.end())
+                event.unsigned_data = obj.at("unsigned");
+
+        if (obj.find("room_id") != obj.end())
+                event.room_id = obj.at("room_id");
 }
 
 enum class MessageType

--- a/include/mtx/events/collections.hpp
+++ b/include/mtx/events/collections.hpp
@@ -7,6 +7,7 @@
 #include "mtx/events/avatar.hpp"
 #include "mtx/events/canonical_alias.hpp"
 #include "mtx/events/create.hpp"
+#include "mtx/events/encrypted.hpp"
 #include "mtx/events/encryption.hpp"
 #include "mtx/events/guest_access.hpp"
 #include "mtx/events/history_visibility.hpp"
@@ -80,6 +81,7 @@ using TimelineEvents = mpark::variant<events::StateEvent<states::Aliases>,
                                       events::StateEvent<states::PinnedEvents>,
                                       events::StateEvent<states::PowerLevels>,
                                       events::StateEvent<states::Topic>,
+                                      events::EncryptedEvent<msgs::Encrypted>,
                                       events::RedactionEvent<msgs::Redaction>,
                                       events::Sticker,
                                       events::RoomEvent<msgs::Redacted>,

--- a/include/mtx/events/encrypted.hpp
+++ b/include/mtx/events/encrypted.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <json.hpp>
+
+using json = nlohmann::json;
+
+namespace mtx {
+namespace events {
+namespace msg {
+
+//! Content of the `m.room.encrypted` event.
+//! Endpoint is `PUT /_matrix/client/r0/rooms/{roomId}/send/m.room.encrypted/{txnId}`.
+struct Encrypted
+{
+        //! Used for one-on-one exchanges.
+        std::string algorithm = "m.megolm.v1.aes-sha2";
+        //! The actual encrypted payload.
+        std::string ciphertext;
+        //! Sender's device id.
+        std::string device_id;
+        //! The curve25519 device key.
+        std::string sender_key;
+        //! Outbound group session id.
+        std::string session_id;
+};
+
+void
+to_json(json &obj, const Encrypted &event);
+
+void
+from_json(const json &obj, Encrypted &event);
+
+} // namespace msg
+} // namespace events
+} // namespace mtx

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -16,6 +16,8 @@ getEventType(const std::string &type)
                 return EventType::RoomCanonicalAlias;
         else if (type == "m.room.create")
                 return EventType::RoomCreate;
+        else if (type == "m.room.encrypted")
+                return EventType::RoomEncrypted;
         else if (type == "m.room.encryption")
                 return EventType::RoomEncryption;
         else if (type == "m.room.guest_access")
@@ -56,6 +58,8 @@ to_string(EventType type)
                 return "m.room.canonical_alias";
         case EventType::RoomCreate:
                 return "m.room.create";
+        case EventType::RoomEncrypted:
+                return "m.room.encrypted";
         case EventType::RoomEncryption:
                 return "m.room.encryption";
         case EventType::RoomGuestAccess:

--- a/src/events/encrypted.cpp
+++ b/src/events/encrypted.cpp
@@ -1,0 +1,31 @@
+#include <string>
+
+#include "mtx/events/encrypted.hpp"
+
+namespace mtx {
+namespace events {
+namespace msg {
+
+void
+from_json(const json &obj, Encrypted &content)
+{
+        content.algorithm  = obj.at("algorithm").get<std::string>();
+        content.ciphertext = obj.at("ciphertext").get<std::string>();
+        content.device_id  = obj.at("device_id").get<std::string>();
+        content.sender_key = obj.at("sender_key").get<std::string>();
+        content.session_id = obj.at("session_id").get<std::string>();
+}
+
+void
+to_json(json &obj, const Encrypted &content)
+{
+        obj["algorithm"]  = "m.megolm.v1.aes-sha2";
+        obj["ciphertext"] = content.ciphertext;
+        obj["device_id"]  = content.device_id;
+        obj["sender_key"] = content.sender_key;
+        obj["session_id"] = content.session_id;
+}
+
+} // namespace msg
+} // namespace events
+} // namespace mtx

--- a/src/responses/common.cpp
+++ b/src/responses/common.cpp
@@ -98,6 +98,16 @@ parse_timeline_events(const json &events,
 
                         break;
                 }
+                case events::EventType::RoomEncrypted: {
+                        try {
+                                container.emplace_back(
+                                  events::EncryptedEvent<mtx::events::msg::Encrypted>(e));
+                        } catch (json::exception &err) {
+                                log_error(err, e);
+                        }
+
+                        break;
+                }
                 case events::EventType::RoomEncryption: {
                         try {
                                 container.emplace_back(events::StateEvent<Encryption>(e));
@@ -420,6 +430,7 @@ parse_state_events(const json &events,
                         break;
                 }
                 case events::EventType::Sticker:
+                case events::EventType::RoomEncrypted: /* Does this need to be here? */
                 case events::EventType::RoomMessage:
                 case events::EventType::RoomPinnedEvents:
                 case events::EventType::RoomRedaction:
@@ -540,6 +551,7 @@ parse_stripped_events(const json &events,
                         break;
                 }
                 case events::EventType::Sticker:
+                case events::EventType::RoomEncrypted:
                 case events::EventType::RoomEncryption:
                 case events::EventType::RoomMessage:
                 case events::EventType::RoomRedaction:

--- a/tests/events.cpp
+++ b/tests/events.cpp
@@ -529,3 +529,66 @@ TEST(StateEvents, Topic)
         EXPECT_EQ(event.state_key, "");
         EXPECT_EQ(event.content.topic, "Test topic");
 }
+
+TEST(RoomEvents, Encrypted)
+{
+        json data = R"({
+          "content": {
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "ciphertext": "AwgAEnACgAkLmt6qF84IK++J7UDH2Za1YVchHyprqTqsg2yyOwAtHaZTwyNg37afzg8f3r9IsN9r4RNFg7MaZencUJe4qvELiDiopUjy5wYVDAtqdBzer5bWRD9ldxp1FLgbQvBcjkkywYjCsmsq6+hArLd9oAQZnGKn/qLsK+5uNX3PaWzDRC9wZPQvWYYPCTov3jCwXKTPsLKIiTrcCXDqMvnn8m+T3zF/I2zqxg158tnUwWWIw51UO",
+            "device_id": "RJYKSTBOIE",
+            "sender_key": "IlRMeOPX2e0MurIyfWEucYBRVOEEUMrOHqn/8mLqMjA",
+            "session_id": "X3lUlvLELLYxeTx4yOVu6UDpasGEVO0Jbu+QFnm0cKQ"
+          },
+          "event_id": "$143273582443PhrSn:localhost",
+          "origin_server_ts": 1432735824653,
+          "room_id": "!jEsUZKDJdhlrceRyVU:localhost",
+          "sender": "@example:localhost",
+          "type": "m.room.encrypted",
+          "unsigned": {
+            "age": 146,
+            "transaction_id": "m1476648745605.19"
+          }
+        })"_json;
+
+        ns::EncryptedEvent<ns::msg::Encrypted> event = data;
+
+        EXPECT_EQ(event.type, ns::EventType::RoomEncrypted);
+        EXPECT_EQ(event.event_id, "$143273582443PhrSn:localhost");
+        EXPECT_EQ(event.room_id, "!jEsUZKDJdhlrceRyVU:localhost");
+        EXPECT_EQ(event.sender, "@example:localhost");
+        EXPECT_EQ(event.origin_server_ts, 1432735824653L);
+        EXPECT_EQ(event.unsigned_data.age, 146);
+        EXPECT_EQ(event.content.algorithm, "m.megolm.v1.aes-sha2");
+        EXPECT_EQ(
+          event.content.ciphertext,
+          "AwgAEnACgAkLmt6qF84IK++"
+          "J7UDH2Za1YVchHyprqTqsg2yyOwAtHaZTwyNg37afzg8f3r9IsN9r4RNFg7MaZencUJe4qvELiDiopUjy5wYVDAt"
+          "qdBzer5bWRD9ldxp1FLgbQvBcjkkywYjCsmsq6+hArLd9oAQZnGKn/"
+          "qLsK+5uNX3PaWzDRC9wZPQvWYYPCTov3jCwXKTPsLKIiTrcCXDqMvnn8m+T3zF/I2zqxg158tnUwWWIw51UO");
+        EXPECT_EQ(event.content.device_id, "RJYKSTBOIE");
+        EXPECT_EQ(event.content.sender_key, "IlRMeOPX2e0MurIyfWEucYBRVOEEUMrOHqn/8mLqMjA");
+        EXPECT_EQ(event.content.session_id, "X3lUlvLELLYxeTx4yOVu6UDpasGEVO0Jbu+QFnm0cKQ");
+
+        ns::msg::Encrypted e1;
+        // e1.algorithm  = "m.megolm.v1.aes-sha2";
+        e1.ciphertext = "AwgAEoABgw1DG6mgKwvrAJU+V7jPu3poEaujNWPnMtIO6+1kFHzEcK6vbYpbg/WlPq/"
+                        "B23wqKWJ3DIaBsV305VdpisGK7dMN5WgnnTp9JhtztxpCuXnX92rWFBUFM9+"
+                        "PC5xVJExVBm1qwv8xgWjD5NFqfcVsZ3jLGbGiftPHairq8bxPxTsjrblMHLpXyXLhK6A7YGTey"
+                        "okcrdXS+IQ4Apq1RLP+kw5RF6M8a/aK3UhUlSAf7OLjaj/03qEwE3TGNaBbLBdOxzoGpxNfQ8";
+        e1.device_id  = "YEGDJGLQTZ";
+        e1.sender_key = "FyYq6RrnjvsIw0XLGF1jHYlorPgDmJQd15lMJw3D7QI";
+        e1.session_id = "/bHcdWPHsJLFd8dkyvG0n7q/RTDmfBIc+gC4laHJCQQ";
+
+        json j = e1;
+        ASSERT_EQ(
+          j.dump(),
+          "{\"algorithm\":\"m.megolm.v1.aes-sha2\","
+          "\"ciphertext\":\"AwgAEoABgw1DG6mgKwvrAJU+V7jPu3poEaujNWPnMtIO6+1kFHzEcK6vbYpbg/"
+          "WlPq/B23wqKWJ3DIaBsV305VdpisGK7dMN5WgnnTp9JhtztxpCuXnX92rWFBUFM9"
+          "+PC5xVJExVBm1qwv8xgWjD5NFqfcVsZ3jLGbGiftPHairq8bxPxTsjrblMHLpXyXLhK6A7YGTeyokcrdXS"
+          "+IQ4Apq1RLP+kw5RF6M8a/aK3UhUlSAf7OLjaj/03qEwE3TGNaBbLBdOxzoGpxNfQ8\","
+          "\"device_id\":\"YEGDJGLQTZ\","
+          "\"sender_key\":\"FyYq6RrnjvsIw0XLGF1jHYlorPgDmJQd15lMJw3D7QI\","
+          "\"session_id\":\"/bHcdWPHsJLFd8dkyvG0n7q/RTDmfBIc+gC4laHJCQQ\"}");
+}


### PR DESCRIPTION
Only supports one-to-one payload for now (megolm).

The best document I've found so far is this: https://matrix.org/speculator/spec/drafts%2Fe2e/client_server/unstable.html#end-to-end-encryption