### PR TITLE
Parse room specific account_data and tag events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SRC
     src/events/pinned_events.cpp
     src/events/power_levels.cpp
     src/events/redaction.cpp
+    src/events/tag.cpp
     src/events/topic.cpp
     src/events/messages/audio.cpp
     src/events/messages/emote.cpp

--- a/include/mtx.hpp
+++ b/include/mtx.hpp
@@ -15,6 +15,7 @@
 #include "mtx/events/pinned_events.hpp"
 #include "mtx/events/power_levels.hpp"
 #include "mtx/events/redaction.hpp"
+#include "mtx/events/tag.hpp"
 #include "mtx/events/topic.hpp"
 
 #include "mtx/events/messages/audio.hpp"

--- a/include/mtx/events.hpp
+++ b/include/mtx/events.hpp
@@ -50,6 +50,8 @@ enum class EventType
         RoomPinnedEvents,
         // m.sticker
         Sticker,
+        // m.tag
+        Tag,
         // Unsupported event
         Unsupported,
 };
@@ -137,6 +139,8 @@ to_json(json &obj, const Event<Content> &event)
         case EventType::Sticker:
                 obj["type"] = "m.sticker";
                 break;
+        case EventType::Tag:
+                obj["type"] = "m.tag";
         case EventType::Unsupported:
                 std::cout << "Unsupported type to serialize" << std::endl;
                 break;

--- a/include/mtx/events/collections.hpp
+++ b/include/mtx/events/collections.hpp
@@ -17,6 +17,7 @@
 #include "mtx/events/pinned_events.hpp"
 #include "mtx/events/power_levels.hpp"
 #include "mtx/events/redaction.hpp"
+#include "mtx/events/tag.hpp"
 #include "mtx/events/topic.hpp"
 
 #include "mtx/events/messages/audio.hpp"
@@ -33,8 +34,12 @@ namespace events {
 //! Contains heterogeneous collections of events using std::variant.
 namespace collections {
 
+namespace account_data = mtx::events::account_data;
 namespace states = mtx::events::state;
 namespace msgs   = mtx::events::msg;
+
+//! Collection of room specific account data
+using RoomAccountDataEvents = mpark::variant<events::Event<account_data::Tag>>;
 
 //! Collection of @p StateEvent only.
 using StateEvents = mpark::variant<events::StateEvent<states::Aliases>,
@@ -232,6 +237,7 @@ from_json(const json &obj, TimelineEvent &e)
         }
         case events::EventType::RoomPinnedEvents:
         case events::EventType::RoomKeyRequest: // Not part of the timeline
+        case events::EventType::Tag: // Not part of the timeline
         case events::EventType::Unsupported:
                 return;
         }

--- a/include/mtx/events/collections.hpp
+++ b/include/mtx/events/collections.hpp
@@ -35,8 +35,8 @@ namespace events {
 namespace collections {
 
 namespace account_data = mtx::events::account_data;
-namespace states = mtx::events::state;
-namespace msgs   = mtx::events::msg;
+namespace states       = mtx::events::state;
+namespace msgs         = mtx::events::msg;
 
 //! Collection of room specific account data
 using RoomAccountDataEvents = mpark::variant<events::Event<account_data::Tag>>;
@@ -237,7 +237,7 @@ from_json(const json &obj, TimelineEvent &e)
         }
         case events::EventType::RoomPinnedEvents:
         case events::EventType::RoomKeyRequest: // Not part of the timeline
-        case events::EventType::Tag: // Not part of the timeline
+        case events::EventType::Tag:            // Not part of the timeline
         case events::EventType::Unsupported:
                 return;
         }

--- a/include/mtx/events/tag.hpp
+++ b/include/mtx/events/tag.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <json.hpp>
+#include <string>
+
+using json = nlohmann::json;
+
+namespace mtx {
+namespace events {
+namespace account_data {
+
+//! Content for the `m.tag` room account_data event.
+//! A tag is a hort string a client can attach to a room for sorting or advanced functionality.
+struct Tag
+{
+        //! The tag list.
+        //! A tag can have arbitrary JSON data attached
+        std::map<std::string, json> tags;
+};
+
+void
+from_json(const json &obj, Tag &content);
+
+void
+to_json(json &obj, const Tag &content);
+
+} // namespace account_data
+} // namespace events
+} // namespace mtx

--- a/include/mtx/events/tag.hpp
+++ b/include/mtx/events/tag.hpp
@@ -10,7 +10,7 @@ namespace events {
 namespace account_data {
 
 //! Content for the `m.tag` room account_data event.
-//! A tag is a hort string a client can attach to a room for sorting or advanced functionality.
+//! A tag is a short string a client can attach to a room for sorting or advanced functionality.
 struct Tag
 {
         //! The tag list.

--- a/include/mtx/responses/common.hpp
+++ b/include/mtx/responses/common.hpp
@@ -38,6 +38,7 @@ from_json(const nlohmann::json &obj, FilterId &response);
 
 namespace utils {
 
+using RoomAccountDataEvents = std::vector<mtx::events::collections::RoomAccountDataEvents>;
 using TimelineEvents = std::vector<mtx::events::collections::TimelineEvents>;
 using StateEvents    = std::vector<mtx::events::collections::StateEvents>;
 using StrippedEvents = std::vector<mtx::events::collections::StrippedEvents>;
@@ -47,6 +48,9 @@ log_error(json::exception &err, const json &event);
 
 void
 log_error(std::string err, const json &event);
+
+void
+parse_room_account_data_events(const json &events, RoomAccountDataEvents &container);
 
 void
 parse_timeline_events(const json &events, TimelineEvents &container);

--- a/include/mtx/responses/common.hpp
+++ b/include/mtx/responses/common.hpp
@@ -39,9 +39,9 @@ from_json(const nlohmann::json &obj, FilterId &response);
 namespace utils {
 
 using RoomAccountDataEvents = std::vector<mtx::events::collections::RoomAccountDataEvents>;
-using TimelineEvents = std::vector<mtx::events::collections::TimelineEvents>;
-using StateEvents    = std::vector<mtx::events::collections::StateEvents>;
-using StrippedEvents = std::vector<mtx::events::collections::StrippedEvents>;
+using TimelineEvents        = std::vector<mtx::events::collections::TimelineEvents>;
+using StateEvents           = std::vector<mtx::events::collections::StateEvents>;
+using StrippedEvents        = std::vector<mtx::events::collections::StrippedEvents>;
 
 void
 log_error(json::exception &err, const json &event);

--- a/include/mtx/responses/sync.hpp
+++ b/include/mtx/responses/sync.hpp
@@ -12,6 +12,16 @@ using json = nlohmann::json;
 namespace mtx {
 namespace responses {
 
+//! Room specific Account Data events.
+struct RoomAccountData
+{
+        //! List of events.
+        std::vector<events::collections::RoomAccountDataEvents> events;
+};
+
+void
+from_json(const json &obj, RoomAccountData &account_data);
+
 //! State events.
 struct State
 {
@@ -78,7 +88,8 @@ struct JoinedRoom
         //! The ephemeral events in the room that aren't recorded in the
         //! timeline or state of the room. e.g. typing.
         Ephemeral ephemeral;
-        /* AccountData account_data; */
+        //! The account_data events associated with this room.
+        RoomAccountData account_data;
 };
 
 void

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -44,6 +44,8 @@ getEventType(const std::string &type)
                 return EventType::RoomPinnedEvents;
         else if (type == "m.sticker")
                 return EventType::Sticker;
+        else if (type == "m.tag")
+                return EventType::Tag;
 
         return EventType::Unsupported;
 }
@@ -88,6 +90,8 @@ to_string(EventType type)
                 return "m.room.pinned_events";
         case EventType::Sticker:
                 return "m.sticker";
+        case EventType::Tag:
+                return "m.tag";
         case EventType::Unsupported:
                 return "";
         }

--- a/src/events/tag.cpp
+++ b/src/events/tag.cpp
@@ -1,0 +1,25 @@
+#include <string>
+
+#include "mtx/events/tag.hpp"
+
+using json = nlohmann::json;
+
+namespace mtx {
+namespace events {
+namespace account_data {
+
+void
+from_json(const json &obj, Tag &content)
+{
+    content.tags = obj.at("tags").get<std::map<std::string, json>>();
+}
+
+void
+to_json(json &obj, const Tag &content)
+{
+    obj["tags"] = content.tags;
+}
+
+} // namespace state
+} // namespace events
+} // namespace mtx

--- a/src/responses/sync.cpp
+++ b/src/responses/sync.cpp
@@ -8,6 +8,12 @@ namespace mtx {
 namespace responses {
 
 void
+from_json(const json &obj, RoomAccountData &account_data)
+{
+        utils::parse_room_account_data_events(obj.at("events"), account_data.events);
+}
+
+void
 from_json(const json &obj, State &state)
 {
         utils::parse_state_events(obj.at("events"), state.events);
@@ -86,6 +92,11 @@ from_json(const json &obj, JoinedRoom &room)
 
         if (obj.find("ephemeral") != obj.end())
                 room.ephemeral = obj.at("ephemeral").get<Ephemeral>();
+
+        if (obj.count("account_data") != 0) {
+                if (obj.at("account_data").count("events") != 0)
+                        room.account_data = obj.at("account_data").get<RoomAccountData>();
+        }
 }
 
 void

--- a/tests/events.cpp
+++ b/tests/events.cpp
@@ -53,6 +53,7 @@ TEST(Events, Conversions)
         EXPECT_EQ("m.room.topic", ns::to_string(ns::EventType::RoomTopic));
         EXPECT_EQ("m.room.redaction", ns::to_string(ns::EventType::RoomRedaction));
         EXPECT_EQ("m.room.pinned_events", ns::to_string(ns::EventType::RoomPinnedEvents));
+        EXPECT_EQ("m.tag", ns::to_string(ns::EventType::Tag));
 }
 
 TEST(StateEvents, Aliases)
@@ -736,4 +737,32 @@ TEST(Collection, Events)
         mtx::events::collections::TimelineEvent event = data;
 
         ASSERT_TRUE(mpark::holds_alternative<ns::StateEvent<ns::state::Aliases>>(event.data));
+}
+
+TEST(RoomAccountData, Tag)
+{
+        json data = R"({
+          "content": {
+              "tags": {
+                "m.favourite": {
+                  "order": 1
+                },
+                "u.Project1": {
+                  "order": 0
+                },
+                "com.example.nheko.text": {
+                  "associated_data": ["some", "json", "list"]
+                }
+              }
+          },
+          "type": "m.tag"
+        })"_json;
+
+        ns::Event<ns::account_data::Tag> event = data;
+
+        EXPECT_EQ(event.type, ns::EventType::Tag);
+        EXPECT_EQ(event.content.tags.size(), 3);
+        EXPECT_EQ(event.content.tags.at("m.favourite").at("order"), 1);
+        EXPECT_EQ(event.content.tags.at("u.Project1").at("order"), 0);
+        EXPECT_EQ(event.content.tags.at("com.example.nheko.text").at("associated_data").size(), 3);
 }

--- a/tests/responses.cpp
+++ b/tests/responses.cpp
@@ -340,6 +340,7 @@ TEST(Responses, Sync)
         EXPECT_EQ(nheko.timeline.limited, true);
         EXPECT_EQ(nheko.timeline.prev_batch,
                   "t10853-333025362_324502987_444424_65663508_21685260_193623_2377336_2940807_454");
+        EXPECT_EQ(nheko.account_data.events.size(), 1);
 
         EXPECT_EQ(sync1.rooms.leave.size(), 1);
         EXPECT_EQ(sync1.rooms.invite.size(), 0);


### PR DESCRIPTION
This introduces the parsing of room-specific `"account_data"` in the `sync` response, as well as extracting the `m.tag` events from it.

This is the first stone for work towards https://github.com/mujx/nheko/issues/80